### PR TITLE
Check empty identifiers

### DIFF
--- a/openid/server/server.py
+++ b/openid/server/server.py
@@ -579,11 +579,11 @@ class CheckIDRequest(OpenIDRequest):
                 s = "OpenID 1 message did not contain openid.identity"
                 raise ProtocolError(message, text=s)
         else:
-            if identity and not claimed_id:
+            if identity is not None and claimed_id is None:
                 s = ("OpenID 2.0 message contained openid.identity but not "
                      "claimed_id")
                 raise ProtocolError(message, text=s)
-            elif claimed_id and not identity:
+            elif identity is None and claimed_id is not None:
                 s = ("OpenID 2.0 message contained openid.claimed_id but not "
                      "identity")
                 raise ProtocolError(message, text=s)

--- a/openid/test/test_server.py
+++ b/openid/test/test_server.py
@@ -284,6 +284,28 @@ class TestDecode(unittest.TestCase):
         self.assertEqual(r.trust_root, self.tr_url)
         self.assertEqual(r.return_to, self.rt_url)
 
+    def test_checkidSetupEmptyIdentityOpenID2(self):
+        args = {
+            'openid.ns': OPENID2_NS,
+            'openid.mode': 'checkid_setup',
+            'openid.assoc_handle': self.assoc_handle,
+            'openid.return_to': self.rt_url,
+            'openid.realm': self.tr_url,
+            'openid.identity': '',
+        }
+        self.assertRaises(server.ProtocolError, self.decode, args)
+
+    def test_checkidSetupEmptyClaimedIDOpenID2(self):
+        args = {
+            'openid.ns': OPENID2_NS,
+            'openid.mode': 'checkid_setup',
+            'openid.assoc_handle': self.assoc_handle,
+            'openid.return_to': self.rt_url,
+            'openid.realm': self.tr_url,
+            'openid.claimed_id': '',
+        }
+        self.assertRaises(server.ProtocolError, self.decode, args)
+
     def test_checkidSetupNoReturnOpenID1(self):
         """Make sure an OpenID 1 request cannot be decoded if it lacks
         a return_to.


### PR DESCRIPTION
Check if identifiers are defined instead of whether they're empty.
See
http://openid.net/specs/openid-authentication-2_0.html#rfc.section.9.1