### PR TITLE
Fix failing tests

### DIFF
--- a/openid/test/test_cryptutil.py
+++ b/openid/test/test_cryptutil.py
@@ -5,6 +5,7 @@ import os.path
 import random
 import sys
 import unittest
+import warnings
 
 import six
 
@@ -18,15 +19,17 @@ class TestLongBinary(unittest.TestCase):
 
     def test_binaryLongConvert(self):
         MAX = sys.maxsize
-        for iteration in range(500):
-            n = 0
-            for i in range(10):
-                n += random.randrange(MAX)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=DeprecationWarning)
+            for iteration in range(500):
+                n = 0
+                for i in range(10):
+                    n += random.randrange(MAX)
 
-            s = cryptutil.longToBinary(n)
-            assert isinstance(s, six.binary_type)
-            n_prime = cryptutil.binaryToLong(s)
-            assert n == n_prime, (n, n_prime)
+                s = cryptutil.longToBinary(n)
+                assert isinstance(s, six.binary_type)
+                n_prime = cryptutil.binaryToLong(s)
+                assert n == n_prime, (n, n_prime)
 
         cases = [
             (b'\x00', 0),
@@ -39,11 +42,13 @@ class TestLongBinary(unittest.TestCase):
             (b'OpenID is cool', 1611215304203901150134421257416556)
         ]
 
-        for s, n in cases:
-            n_prime = cryptutil.binaryToLong(s)
-            s_prime = cryptutil.longToBinary(n)
-            assert n == n_prime, (s, n, n_prime)
-            assert s == s_prime, (n, s, s_prime)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=DeprecationWarning)
+            for s, n in cases:
+                n_prime = cryptutil.binaryToLong(s)
+                s_prime = cryptutil.longToBinary(n)
+                assert n == n_prime, (s, n, n_prime)
+                assert s == s_prime, (n, s, s_prime)
 
 
 class TestFixBtwoc(unittest.TestCase):

--- a/openid/test/test_fetchers.py
+++ b/openid/test/test_fetchers.py
@@ -401,7 +401,7 @@ class TestRequestsFetcher(unittest.TestCase):
         # Test GET response
         with responses.RequestsMock() as rsps:
             rsps.add(responses.GET, 'http://example.cz/', status=200, body=b'BODY',
-                     headers={'Content-Type': 'text/plain'})
+                     content_type='text/plain')
             response = self.fetcher.fetch('http://example.cz/')
         expected = fetchers.HTTPResponse('http://example.cz/', 200, {'Content-Type': 'text/plain'}, b'BODY')
         assertResponse(expected, response)
@@ -410,7 +410,7 @@ class TestRequestsFetcher(unittest.TestCase):
         # Test POST response
         with responses.RequestsMock() as rsps:
             rsps.add(responses.POST, 'http://example.cz/', status=200, body=b'BODY',
-                     headers={'Content-Type': 'text/plain'})
+                     content_type='text/plain')
             response = self.fetcher.fetch('http://example.cz/', body=b'key=value')
         expected = fetchers.HTTPResponse('http://example.cz/', 200, {'Content-Type': 'text/plain'}, b'BODY')
         assertResponse(expected, response)
@@ -421,7 +421,7 @@ class TestRequestsFetcher(unittest.TestCase):
             rsps.add(responses.GET, 'http://example.cz/redirect/', status=302,
                      headers={'Location': 'http://example.cz/target/'})
             rsps.add(responses.GET, 'http://example.cz/target/', status=200, body=b'BODY',
-                     headers={'Content-Type': 'text/plain'})
+                     content_type='text/plain')
             response = self.fetcher.fetch('http://example.cz/redirect/')
         expected = fetchers.HTTPResponse('http://example.cz/target/', 200, {'Content-Type': 'text/plain'}, b'BODY')
         assertResponse(expected, response)
@@ -430,14 +430,18 @@ class TestRequestsFetcher(unittest.TestCase):
         # Test error responses - returned as obtained
         with responses.RequestsMock() as rsps:
             rsps.add(responses.GET, 'http://example.cz/error/', status=500, body=b'BODY',
-                     headers={'Content-Type': 'text/plain'})
+                     content_type='text/plain')
             response = self.fetcher.fetch('http://example.cz/error/')
         expected = fetchers.HTTPResponse('http://example.cz/error/', 500, {'Content-Type': 'text/plain'}, b'BODY')
         assertResponse(expected, response)
 
     def test_invalid_url(self):
         invalid_url = 'invalid://example.cz/'
-        with six.assertRaisesRegex(self, InvalidSchema, "No connection adapters were found for '" + invalid_url + "'"):
+        expected_message = (
+            'No connection adapters were found for '
+            + ('u' if six.PY2 else '')
+            + "'" + invalid_url + "'")
+        with six.assertRaisesRegex(self, InvalidSchema, expected_message):
             self.fetcher.fetch(invalid_url)
 
     def test_connection_error(self):


### PR DESCRIPTION
`responses` needs the content type to be set using the `content_type` keyword argument; using `headers` for this results in responses with `Content-Type: text/plain, text/plain`.

test_invalid_url needs a slight adjustment to pass on Python 2, due to the different `repr` for text strings.

The `cryptutil` tests had some very noisy deprecation warnings.