### PR TITLE
Fix urinorm - return plain sub delimiters in path

### DIFF
--- a/openid/test/test_urinorm.py
+++ b/openid/test/test_urinorm.py
@@ -71,10 +71,16 @@ class UrinormTest(unittest.TestCase):
         self.assertEqual(urinorm('http://example.com/Λ'), 'http://example.com/%CE%9B')
 
     def test_path_capitalize_percent_encoding(self):
-        self.assertEqual(urinorm('http://example.com/foo%2cbar'), 'http://example.com/foo%2Cbar')
+        self.assertEqual(urinorm('http://example.com/foo%3abar'), 'http://example.com/foo%3Abar')
 
     def test_path_percent_decode_unreserved(self):
         self.assertEqual(urinorm('http://example.com/foo%2Dbar%2dbaz'), 'http://example.com/foo-bar-baz')
+
+    def test_path_keep_sub_delims(self):
+        self.assertEqual(urinorm('http://example.com/foo+!bar'), 'http://example.com/foo+!bar')
+
+    def test_path_percent_decode_sub_delims(self):
+        self.assertEqual(urinorm('http://example.com/foo%2B%21bar'), 'http://example.com/foo+!bar')
 
     def test_illegal_characters(self):
         six.assertRaisesRegex(self, ValueError, 'Illegal characters in URI', urinorm, 'http://<illegal>.com/')

--- a/openid/urinorm.py
+++ b/openid/urinorm.py
@@ -122,10 +122,10 @@ def urinorm(uri):
     # This is hackish. `unquote` and `quote` requires `str` in both py27 and py3+.
     if isinstance(path, str):
         # Python 3 branch
-        path = quote(unquote(path))
+        path = quote(unquote(path), safe='/' + SUB_DELIMS)
     else:
         # Python 2 branch
-        path = quote(unquote(path.encode('utf-8'))).decode('utf-8')
+        path = quote(unquote(path.encode('utf-8')), safe=('/' + SUB_DELIMS).encode('utf-8')).decode('utf-8')
 
     path = remove_dot_segments(path)
     if not path:


### PR DESCRIPTION
Reduce the strictness of percent encoding in path of `urinorm` as reported in #41 